### PR TITLE
Fix spelling in macOS background comment

### DIFF
--- a/FundoZeCopa.py
+++ b/FundoZeCopa.py
@@ -13,7 +13,7 @@ original_image_path = "FundoZeCopa.png"
 #Precisa descobrir qual a pasta e qual o nome de arquivo que o seu zoom usou para salvar o seu background em uso
 #Vc pode fazer isso adicionando um background novo e verificando a data dos arquivos
 #Padrao Windows: C:\\Users\\Username\\AppData\\Roaming\\Zoom\\data\\VirtualBkgnd_Custom\\{FFCB4691-A4F1-4031-AD05-C62BA8B7510D}
-#Padaro macOS: /Users/Username/Library/Application Support/zoom.us/data/VirtualBkgnd_Custom/63327A14-224B-49B1-8E66-30AF4686089A
+#Padrão macOS: /Users/Username/Library/Application Support/zoom.us/data/VirtualBkgnd_Custom/63327A14-224B-49B1-8E66-30AF4686089A
 
 arquivo_fundo_zoom = "/Users/zeuser/Library/Application Support/zoom.us/data/VirtualBkgnd_Custom/63327A14-224B-49B1-8E66-30AF4686089A"
 


### PR DESCRIPTION
## Summary
- fix a typo in the macOS background path comment of `FundoZeCopa.py`

## Testing
- `python -m py_compile FundoZeCopa.py`

------
https://chatgpt.com/codex/tasks/task_e_687a93378b58832faf382c262997c016