### PR TITLE
Fix indentation error and expand text position tests

### DIFF
--- a/FundoZeCopa.py
+++ b/FundoZeCopa.py
@@ -44,44 +44,50 @@ height_text_pos = "25"
 #======================
 
 def get_center_width(image):
-	text_box = image.textbbox((0,0), title_text, font=title_font, align='center', stroke_width=text_stroke_width)
-	return((image.im.size[0]/2)-text_box[2]/2)
-	
+    text_box = image.textbbox((0,0), title_text, font=title_font, align='center', stroke_width=text_stroke_width)
+    return((image.im.size[0]/2)-text_box[2]/2)
+    
 def get_center_height(image):
-	text_box = image.textbbox((0,0), title_text, font=title_font, align='center', stroke_width=text_stroke_width)
-	return((image.im.size[1]/2)-text_box[3]/2)
+    text_box = image.textbbox((0,0), title_text, font=title_font, align='center', stroke_width=text_stroke_width)
+    return((image.im.size[1]/2)-text_box[3]/2)
 
 def get_right_width(image):
-	text_box = image.textbbox((0,0), title_text, font=title_font, align='center', stroke_width=text_stroke_width)
-	return((image.im.size[0])-text_box[2])
+    text_box = image.textbbox((0,0), title_text, font=title_font, align='center', stroke_width=text_stroke_width)
+    return((image.im.size[0])-text_box[2])
 
 def get_bottom_height(image):
         text_box = image.textbbox((0,0), title_text, font=title_font, align='center', stroke_width=text_stroke_width)
         return((image.im.size[1])-text_box[3])
-	
+    
 def text_position(image):
-	width_return = 0
-	if width_text_pos == "center": width_return = get_center_width(image)
-	elif width_text_pos == "left": width_return = 0
-	elif width_text_pos == "right": width_return = get_right_width(image)
-	else:
-		try:
-			width_return = int(width_text_pos)
-		except:
-			print("Parametro width_text_pos invalido")		
+    width_return = 0
+    if width_text_pos == "center":
+        width_return = get_center_width(image)
+    elif width_text_pos == "left":
+        width_return = 0
+    elif width_text_pos == "right":
+        width_return = get_right_width(image)
+    else:
+        try:
+            width_return = int(width_text_pos)
+        except Exception:
+            print("Parametro width_text_pos invalido")
 
-	height_return = 0
-	if height_text_pos == "center": height_return = get_center_height(image)
-	elif height_text_pos == "top": height_return = 0
-        elif height_text_pos == "bottom": height_return = get_bottom_height(image)
-	else:
-		try:
-			height_return = int(height_text_pos)
-		except:
-			print("Parametro height_text_pos invalido")
-			
-	return (width_return,height_return)
-	
+    height_return = 0
+    if height_text_pos == "center":
+        height_return = get_center_height(image)
+    elif height_text_pos == "top":
+        height_return = 0
+    elif height_text_pos == "bottom":
+        height_return = get_bottom_height(image)
+    else:
+        try:
+            height_return = int(height_text_pos)
+        except Exception:
+            print("Parametro height_text_pos invalido")
+
+    return (width_return, height_return)
+    
 
 #Montando Imagem
 my_image = Image.open(original_image_path)

--- a/tests/test_text_position.py
+++ b/tests/test_text_position.py
@@ -31,3 +31,52 @@ def test_text_position_center():
     expected_x = (img.size[0] - bbox[2]) / 2
     expected_y = (img.size[1] - bbox[3]) / 2
     assert (x, y) == (expected_x, expected_y)
+
+
+def test_text_position_left_top():
+    fundo = load_module()
+    fundo.width_text_pos = 'left'
+    fundo.height_text_pos = 'top'
+    fundo.title_text = 'Test'
+    fundo.title_font = ImageFont.load_default()
+    fundo.text_stroke_width = 0
+
+    img = Image.new('RGB', (100, 50), 'white')
+    draw = ImageDraw.Draw(img)
+
+    x, y = fundo.text_position(draw)
+    assert (x, y) == (0, 0)
+
+
+def test_text_position_right_bottom():
+    fundo = load_module()
+    fundo.width_text_pos = 'right'
+    fundo.height_text_pos = 'bottom'
+    fundo.title_text = 'Test'
+    fundo.title_font = ImageFont.load_default()
+    fundo.text_stroke_width = 0
+
+    img = Image.new('RGB', (100, 50), 'white')
+    draw = ImageDraw.Draw(img)
+
+    x, y = fundo.text_position(draw)
+    bbox = draw.textbbox((0, 0), fundo.title_text, font=fundo.title_font,
+                          align='center', stroke_width=fundo.text_stroke_width)
+    expected_x = img.size[0] - bbox[2]
+    expected_y = img.size[1] - bbox[3]
+    assert (x, y) == (expected_x, expected_y)
+
+
+def test_text_position_numeric():
+    fundo = load_module()
+    fundo.width_text_pos = '10'
+    fundo.height_text_pos = '20'
+    fundo.title_text = 'Test'
+    fundo.title_font = ImageFont.load_default()
+    fundo.text_stroke_width = 0
+
+    img = Image.new('RGB', (100, 50), 'white')
+    draw = ImageDraw.Draw(img)
+
+    x, y = fundo.text_position(draw)
+    assert (x, y) == (10, 20)


### PR DESCRIPTION
## Summary
- fix mixed indentation in `FundoZeCopa.py`
- restructure `text_position` logic
- add tests for left/top, right/bottom and numeric text positions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a9f3cfac8832f9d47bf70e17e357d